### PR TITLE
chore: add repo info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "glimmer",
     "ember"
   ],
-  "repository": "",
+  "repository": "https://github.com/linkedin/tracked-queue",
   "license": "BSD-2-Clause",
   "contributors": [
     {


### PR DESCRIPTION
Useful for all sorts of tooling, including (and how I realized I was missing it) release-it.