### PR TITLE
Remove ember-auto-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@typescript-eslint/parser": "^4.22.1",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-auto-import": "^1.11.3",
     "ember-cli": "~3.26.1",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",


### PR DESCRIPTION
This addon doesn't actually use any of the auto-import functionality, and bumping to 2.0 was going to require a significant set of breaking changes. While those changes *will* be necessary as part of moving to Embroider in the future, they're not necessary here or now.