### PR TITLE
Remove special handling for Ember <3.24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,8 +79,6 @@ jobs:
     strategy:
       matrix:
         ember-version:
-          - 'lts-3.16'
-          - 'lts-3.20'
           - 'lts-3.24'
           # - 'release'
           # - 'beta'

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,22 +7,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.24',
         npm: {
           devDependencies: {


### PR DESCRIPTION
- Drop Embroider macros-based handling for Ember 3.22 and earlier, and simply require the use of the tracked storage primitives.
- Drop Ember 3.16 and 3.20 from Ember Try config and CI config.