### PR TITLE
Update compatibility test suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,7 @@ jobs:
     name: 'Tests: ubuntu (node@${{ matrix.node-version }})'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: ['14', '16']
 
@@ -57,6 +58,7 @@ jobs:
       THROW_UNLESS_PARALLELIZABLE: '1'
 
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS, windows]
 
@@ -77,6 +79,7 @@ jobs:
       THROW_UNLESS_PARALLELIZABLE: '1'
 
     strategy:
+      fail-fast: false
       matrix:
         ember-version:
           - 'lts-3.24'
@@ -99,6 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     strategy:
+      fail-fast: false
       matrix:
         ts-version:
           - '4.4'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,9 +80,10 @@ jobs:
       matrix:
         ember-version:
           - 'lts-3.24'
-          # - 'release'
-          # - 'beta'
-          # - 'canary'
+          - 'lts-3.28'
+          - 'release'
+          - 'beta'
+          - 'canary'
 
     steps:
       - uses: actions/checkout@v2

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -10,7 +10,15 @@ module.exports = async function () {
         name: 'ember-lts-3.24',
         npm: {
           devDependencies: {
-            'ember-source': '~3.24.3',
+            'ember-source': '~3.24',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-3.28',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.28',
           },
         },
       },


### PR DESCRIPTION
- Add Ember v3.28 LTS to the mix now that the package itself targets Ember v4.4.
- Loosen the constraint on 3.24 LTS to `~3.24`: this should not matter but is preferable.
- Reenable `release`, `beta`, and `canary` tests.